### PR TITLE
add avl-search

### DIFF
--- a/avl/avl.scrbl
+++ b/avl/avl.scrbl
@@ -110,6 +110,27 @@ remove elements from the middle.
   ]
 }
 
+@defproc[(avl-search (tree avl?) (value any/c)) any/c?]{
+  Search the tree and return a needle corresponding 
+  to the specified @racket[value].  Return #f if none exist.
+
+  @examples[#:eval avl-eval
+    (define animal-dict
+      (make-custom-avl (λ (x y) (<= (car x) (car y)))
+                       (λ (x y) (equal? (car x) (car y)))))
+    (avl-add! animal-dict (cons 1 'cat))
+    (avl-add! animal-dict (cons 2 'dog))
+    (avl-add! animal-dict (cons 3 'mouse))
+    (avl->list animal-dict)
+
+    (define (search-by-key tree key)
+      (avl-search tree (cons key '())))
+    (search-by-key animal-dict 1)
+    (search-by-key animal-dict 2)
+    (search-by-key animal-dict 3)
+    (search-by-key animal-dict 4)
+  ]
+}
 
 @section{Manipulating Values}
 

--- a/avl/main.rkt
+++ b/avl/main.rkt
@@ -32,6 +32,7 @@
     (avl-eqv? (-> any/c boolean?))
     (avl-eq? (-> any/c boolean?))
     (avl-contains? (-> avl? any/c boolean?))
+    (avl-search (-> avl? any/c any/c))
     (avl->list (-> avl? list?))
     (in-avl (-> avl? sequence?))
     (in-avl/reverse (-> avl? sequence?))))
@@ -374,6 +375,27 @@
        (else
         (contains? <=? =? right needle))))
 
+    (else #f)))
+
+;; Determine whether the tree contains specified value.
+;; Return the needle contained by the tree
+(define (avl-search tree value)
+  (match tree
+    ((avl <=? =? root)
+     (find <=? =? root value))))
+
+
+;; Return value corresponding to specified needle.
+(define (find <=? =? parent needle)
+  (match parent
+    ((node left right value _)
+     (cond
+       ((=? value needle)
+        (begin value))
+       ((<=? needle value)
+        (find <=? =? left needle))
+       (else
+         (find <=? =? right needle))))
     (else #f)))
 
 


### PR DESCRIPTION
`avl-search` returns a needle which is equivalent to the specified value, or #f if none exists.  It is useful for using avl trees to implement simple maps/dictionaries.  The implementation is based on that of `avl-contains`.

The documentation has been updated with an example of how the procedure is evaluated.